### PR TITLE
Tag menu errors and empty post tags, fixes #15, fixes #23

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -71,7 +71,9 @@
             "SELECT postid, postdatetime FROM posts WHERE postid = '$value'",
             "SELECT postcontent FROM posts WHERE postid = '$value'",
             "SELECT * FROM posts WHERE postid = '$value'",
-            "SELECT * FROM posts_tags WHERE posts_postid = '$value'"
+            "SELECT * FROM posts_tags WHERE posts_postid = '$value'",
+            "SELECT * FROM posts WHERE postid = (SELECT MIN(postid) FROM posts WHERE postid < '$value')",
+            "SELECT postid FROM posts ORDER BY postid DESC"
             );
         
         $fields = array("catname", "tagname", "postcontent", "tagid", "MAX", "MIN", "catid", "postdatetime", "postid", "posts_postid");
@@ -114,6 +116,12 @@
         }
     }
 
+
+    function getPostIDs() {
+        $postIDs = array();
+        $postIDs = query_select(13, 8, "none", "none", "none", "none");
+        return $postIDs;
+    }
 
     function getPostContent($postID) {
         
@@ -213,6 +221,13 @@
     function delPost ($postID) {
         query_delete(0, $postID);
         query_delete(1, $postID);
+    }
+
+
+    function getNextPostID($postID) {
+        $nextID = query_select(12, 8, $postID, "none", "none", "none");
+        $nextID = $nextID[0];
+        return $nextID;
     }
 
 ?>

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,5 @@
 <?php
-    require("../includes/config.php"); 
+require("../includes/config.php"); 
 //echo '<pre>';
 //print_r($_POST);
 //echo '</pre>';
@@ -20,33 +20,39 @@
 						
 						<?php
 						//********************************this part is for loading the header and loading a post (and tags) if editing**********
-						//********************************so when i hit edit -OR- *delete*, this code is executed on postback*******************
+						//********************************so when i hit post, edit -OR- *delete*, this code is executed on postback*******************					
 							$postTagsArray = array();
 							$postID = "";
 							$postContent = "";
 							
 							if (isset($_POST["postID"])) {
+								
+								//get the set post id
 								$postID = $_POST["postID"];
+
+								if(isset($_POST["edit"])) {
+								
+								//get its contents and tags
+								$postContent = getPostContent($postID);
+								$postContent = $postContent[0];
+								$postTagsArray = getPostTags($postID);
+								}
+								
+								//if delete is also set, then delete the post instead
 								if (isset($_POST["delete"])) {
 									delPost($postID);
-									//$postContent = "";
-									$_POST = array();
-								}
-								else {
-									//find postcontent and tags for post by postID
-									$postContent = getPostContent($postID);
-									$postContent = $postContent[0];
-									$postTagsArray = getPostTags($postID);
+									//echo $postID;
+									//echo "blaaaaaaaaaaaa";
 								}
 							}
-							else {
-								//$postContent = "Type or paste to add new content.";
-								$postContent = "";
-							}
+							//else {
+							//	$postContent = "";
+							//}
 
 							echo "<textarea id='pastebox' name='pastebox' rows='8' cols='100'>" . $postContent . "</textarea>";
+						  
 						  echo "<div id='tag-table'>";
-							echo "<ul id='tag-list'>";
+								echo "<ul id='tag-list'>";
 
 								$cats = getCats();
 								foreach ($cats as $cat) {
@@ -73,11 +79,12 @@
 									}
 								}
 
-							echo "</ul>";
-						echo "</div>";
+								echo "</ul>";
+							echo "</div>";
 
 						echo "<input type='submit' name='post' value='Post'/>";
 						//***************************this is another hidden input so that i can add (keep) postID in $_POST ...IF we were editing... *****
+						//***************************this makes sure the same postid gets edited and we're not doing an insert****************************
 							if ($postID == TRUE) {
 								//echo "postID was set/true";
 								echo "<input type='hidden' name='postID' value='$postID'>";
@@ -108,47 +115,57 @@
     				foreach($_POST['tag_boxes'] as $selected) {
     					$tagsArray[] = $selected;
     				}
+    			
+    				$postDateTime = date("Y-m-d H:i:s");
+    				$lastID = setPostContent($postID, $postContent, $postDateTime);
+    				setPostTags($postID, $tagsArray, $lastID);
     			}
-    			$postDateTime = date("Y-m-d H:i:s");
-    			$lastID = setPostContent($postID, $postContent, $postDateTime);
-    			setPostTags($postID, $tagsArray, $lastID);
+    			else {
+    				echo "<br>";
+    				echo "<p style='color: red;'>No tags selected.<p>";
+    			}
     		}
 
     		echo "<table name='post-table' id='post-table'>";
     		//echo "<ul>";
 
 				
-				//******************this is for displaying posts to table***************    		
-				$postID = getMaxID("posts");
-    		$postContent = getPostContent("all");
-
+				//******************this is for displaying posts to table***************
+				//**********************************************************************    		
+				//$postID = getMaxID("posts");
+    		//$postContent = getPostContent("all");
+    		$postIDs = getPostIDs();
     		//loop through posts
-	    	if ($postContent) {	
-	    		foreach ($postContent as $post) {
-	    			$post = nl2br($post);
-	    			$postTagString = "";
-	    			$postTags = getPostTags($postID);
-	    			$postDateTimeArray = getPostDateTime($postID);
+	    	if ($postIDs) {										//if i got anything from getPostContent
+	    		foreach ($postIDs as $postID) {
+	    			//echo "postContent[3]: " . $postContent[3];
+	    			$postContent = getPostContent($postID);
+	    			$postContent = nl2br($postContent[0]);							//then replace new lines with breaks
+	    			$postTagString = "";							//initialize $postTagString
+	    			$postTags = getPostTags($postID); //get tags based on the post id
+	    			$postDateTimeArray = getPostDateTime($postID);	//get date and time
 	    			$postDateTime = $postDateTimeArray[0];
 
-	    			if (!($postTags)) {
-	    				$postTagString = "";
+	    			if (!($postTags)) {				//if there were no tags
+	    				$postTagString = "";		//then provide empty string
 	    			}
 	    			else {
 
-		    			//loop through tags of each post
+		    			//otherwise loop through tags of each post
 		    			foreach ($postTags as $postTag) {
-		    				$postTagString .= "<div class='tag-bottom'>" . $postTag . "</div>";
+		    				$postTagString .= "<div class='tag-bottom'>" . $postTag . "</div>";  //and concatenate a string of tags including <div>'s
 		    			}
 						}
 	    			
-	    			$postTagString = rtrim($postTagString, ', ');
+	    			$postTagString = rtrim($postTagString, ', ');  //trim off the trailing commas
 
+	    			//and now display everything
 	    			echo "<tr id='post-row'>";
 	    			//echo "<li>";
 	    			echo "<td class='post-column-posts'>";
+	    			//echo $postID;
 	    			echo "<div class='post-date-time'>" . $postDateTime . "</div><br>";
-	    			echo "<div class='post-content'>" . $post . "</div><br>";
+	    			echo "<div class='post-content'>" . $postContent . "</div><br>";
 	    			echo "<div class='post-tags'>" . $postTagString . "</div>";
 
 	    			echo "<div class='post-edit-delete'>";
@@ -158,6 +175,7 @@
 	    			echo "<input type='submit' class='edit' value='Edit'>";
 	    			//provides hidden $postID value to pass to $_POST
 	    			echo "<input type='hidden' name='postID' value='$postID'>";
+	    			echo "<input type='hidden' name='edit' value='TRUE'>";
 	    			echo "</form>";
 	    			echo "</div>";
 
@@ -176,7 +194,7 @@
 	    			echo "</tr>";
 
 	    			//loop through postcontent in reverse since getPostContent() results are sorted opposite
-	    			$postID -= 1;  
+	    			//$postID -= 1;  
 	    		}
 	    	}
 	    	else {


### PR DESCRIPTION
Fixed tags in tag menu failing to load.  Fixed post tags and post date/times pulling based on wrong post id's due to bad counter.

#15
Now checking if no tags were selected after posting.  If none were, it is caught and an error is displayed.

#23
Now pulling all post id's and using "foreach postid" to traverse data instead of a separate counter that was decrementing from the last post in the table.  The counter was wrong if posts had been deleted because post id's were missing.