### PR TITLE
Added link auto formatting Fixes #45

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -266,23 +266,6 @@ if ($devMode === TRUE) {
 	    			$postContent = getPostContent($postID, $limit);
 	    			$postContent = nl2br($postContent[0]);	//then replace new lines with breaks
 
-	    			//find "http://" and "https://" and return their positions in arrays
-	    			//$postContentHttp = findAllSubStrings($postContent, "http://");
-	    			//$postContentHttps = findAllSubStrings($postContent, "https://");
-
-	    			//if($postContentHttp) {
-	    				//foreach ($postContentHttp as $pchttp) {
-	    					//echo $pchttp;
-	    					//echo "<br>";
-	    				//}
-	    			//}
-	    			//if($postContentHttps) {
-	    				//foreach ($postContentHttps as $pchttps) {
-	    					//echo $pchttps;
-	    					//echo "<br>";
-	    				//}
-	    			//}
-
 	    			$postTagString = "";							//initialize $postTagString
 	    			$postTags = getPostTags($postID); //get tags based on the post id
 	    			$postDateTimeArray = getPostDateTime($postID);	//get date and time
@@ -316,6 +299,9 @@ if ($devMode === TRUE) {
 	    			}
 
 	    			echo "<br>";
+
+	    			$postContent = autoFormatLinks($postContent);
+
 	    			echo "<div class='post-content'>" . $postContent . "</div><br>";
 	    			
 	    			echo "<div id='tag-bottom-menu'>";
@@ -385,7 +371,7 @@ if ($devMode === TRUE) {
 		</div>
 		<script>
 			addTagMenuHandlers();
-			addRowHandlers();
+			//addRowHandlers();
 			addNavMenuHandlers();
 		</script>
 		</body>

--- a/public/js/scripts.js
+++ b/public/js/scripts.js
@@ -1,4 +1,4 @@
-function addRowHandlers() {
+/*function addRowHandlers() {
     var table = document.getElementById("post-table");
     var rows = table.getElementsByTagName("tr");
 
@@ -30,7 +30,7 @@ function addRowHandlers() {
         currentRow.onmouseover = createHoverHandler(currentRow);
         currentRow.onmouseout = createLeaveHandler(currentRow);
     }
-}
+}*/
 
 
 function addTagMenuHandlers() {


### PR DESCRIPTION
Disabled row highlighting in JS, no longer favorable (too busy).

Wrote link detection feature on backend to auto format links in posts:

-finds all instances of http:// and https://
-notes link positions, disassembles $postContent at link boundaries and
reassembles with link tags
-accounts for the following:

-no links, one link, multiple links
-links at start of text, end of text, or throughout
-single or mutliple line breaks throughout content
-links at the end of a sentence ending with a period

Fixes #45.